### PR TITLE
Fixes issues in #1

### DIFF
--- a/android/src/main/java/com/freshchat/consumer/sdk/flutter/FreshchatSdkPlugin.java
+++ b/android/src/main/java/com/freshchat/consumer/sdk/flutter/FreshchatSdkPlugin.java
@@ -514,6 +514,7 @@ public class FreshchatSdkPlugin implements FlutterPlugin, MethodCallHandler {
 
                 case "identifyUser":
                     identifyUser(call);
+                    result.success(null);
                     break;
 
                 case "registerForEvent":

--- a/ios/Classes/FreshchatSdkPlugin.h
+++ b/ios/Classes/FreshchatSdkPlugin.h
@@ -1,11 +1,5 @@
 #import <Flutter/Flutter.h>
 
-#if __has_include("FreshchatSDK.h")
-#import "FreshchatSDK.h"
-#else
-#import "FreshchatSDK/FreshchatSDK.h"
-#endif
-
 @interface FreshchatSdkPlugin : NSObject<FlutterPlugin>
 -(void)handlePushNotification:(NSDictionary *) pushPayload;
 -(BOOL)isFreshchatNotification:(NSDictionary *) pushPayload;

--- a/ios/Classes/FreshchatSdkPlugin.m
+++ b/ios/Classes/FreshchatSdkPlugin.m
@@ -1,5 +1,11 @@
 #import "FreshchatSdkPlugin.h"
 
+#if __has_include("FreshchatSDK.h")
+#import "FreshchatSDK.h"
+#else
+#import "FreshchatSDK/FreshchatSDK.h"
+#endif
+
 @implementation FreshchatSdkPlugin
 
 FlutterMethodChannel* channel;
@@ -32,7 +38,7 @@ NSNotificationCenter *center;
         if(![themeName isEqual:[NSNull null]]) {
             freshchatConfig.themeName = themeName;
         }
-        
+
         if(![stringsBundle isEqual:[NSNull null]]) {
             freshchatConfig.stringsBundle = stringsBundle;
         }
@@ -377,6 +383,7 @@ NSNotificationCenter *center;
         result([instance getUserIdTokenStatus]);
     }else if([@"identifyUser" isEqualToString:call.method]){
         [instance identifyUser:call];
+        result(nil);
     }else if([@"setNotificationConfig" isEqualToString:call.method]){
         [instance setNotificationConfig];
     }else if([@"setPushRegistrationToken" isEqualToString:call.method]){

--- a/ios/freshchat_sdk.podspec
+++ b/ios/freshchat_sdk.podspec
@@ -21,4 +21,6 @@ A new flutter plugin project.
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+
+  s.static_framework = true
 end


### PR DESCRIPTION
- [android] calling `result.success(null)` after handling `identifyUser`
- [ios] calling `result[nil]` after handling `identifyUser`
- [ios] import fix - moved `FreshchatSDK.h` import from `FreshchatSdkPlugin.h` to `FreshchatSdkPlugin.m`
- [ios,podspec] added `static_framework = true`, since using "Objective C"

Closes #1 