### PR TITLE
Update dependency and configuration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,7 +15,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url "https://jitpack.io" }
     }
 }
@@ -24,7 +24,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace "com.freshchat.consumer.sdk.flutter"
-    compileSdkVersion 35
+    compileSdk 35
 
     defaultConfig {
         minSdkVersion 21
@@ -36,7 +36,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:localbroadcastmanager:28.0.0'
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
     implementation 'com.github.freshworks:freshchat-android:6.3.9'
 }
 


### PR DESCRIPTION
1. We should use `androidx` package instead of `support` to avoid enabling `android.enableJetifier=true`.

2. Remove deprecated configs